### PR TITLE
Correct temperature setting name in  settings.mjs

### DIFF
--- a/server/scripts/modules/settings.mjs
+++ b/server/scripts/modules/settings.mjs
@@ -23,7 +23,7 @@ const init = () => {
 		[3, 'knots'],
 		[4, 'mph'],
 	]);
-	settings.temperatureUnits = new Setting('windUnits', 'Temperature Units', 'select', 1, temperatureChangeUnits, true, [
+	settings.temperatureUnits = new Setting('temperatureUnits', 'Temperature Units', 'select', 1, temperatureChangeUnits, true, [
 		[1, 'C'],
 		[2, 'F'],
 		[3, 'K'],


### PR DESCRIPTION
settings.mjs uses "windUnits" as the setting name for both windUnits and temperatureUnits, preventing temperatureUnits from being stored in permalinks. 

This change corrects the name to temperatureUnits.