### PR TITLE
Added support for Beaufort wind speed

### DIFF
--- a/server/scripts/modules/settings.mjs
+++ b/server/scripts/modules/settings.mjs
@@ -28,6 +28,7 @@ const init = () => {
 		[2, 'km/h'],
 		[3, 'knots'],
 		[4, 'mph'],
+		[5, 'bft']
 	]);
 	settings.marineWindUnits = new Setting('marineWindUnits', 'Wind Units (Marine)', 'select', 1, marineWindUnitsChange, true, [
 		[1, 'knots'],

--- a/server/scripts/modules/utils/conversionHelpers.mjs
+++ b/server/scripts/modules/utils/conversionHelpers.mjs
@@ -2,6 +2,7 @@ import {
 	kphToKnots,
 	kphToMs,
 	kphToMph,
+	kphToBft,
 	knotsToMs,
 
 	celsiusToFahrenheit,
@@ -96,6 +97,9 @@ export default class ConversionHelpers {
 			case '4':
 				windUnitText = 'mph';
 				break;
+			case '5':
+				windUnitText = 'bft';
+				break;
 			default:
 				windUnitText = 'km/h';
 		}
@@ -108,12 +112,14 @@ export default class ConversionHelpers {
 		// [2, 'km/h'],
 		// [3, 'knots'],
 		// [4, 'mph'],
+		// [5, 'bft'],
 		const windUnits = document.documentElement.attributes.getNamedItem('wind-units').value;
 
 		if (windUnits === '1') return kphToMs(openMeteoValue); // m/s
 		if (windUnits === '2') return openMeteoValue; // km/h
 		if (windUnits === '3') return kphToKnots(openMeteoValue); // knots
 		if (windUnits === '4') return kphToMph(openMeteoValue); // mph
+		if (windUnits === '5') return kphToBft(openMeteoValue); // bft
 		return openMeteoValue;
 	}
 

--- a/server/scripts/modules/utils/units.mjs
+++ b/server/scripts/modules/utils/units.mjs
@@ -6,6 +6,7 @@ const round2 = (value, decimals) => Math.trunc(value * 10 ** decimals) / 10 ** d
 const kphToKnots = (Kph) => Math.round((Kph * 0.539957) * 100) / 100; // 2 decimal places
 const kphToMs = (Kph) => Math.round((Kph / 3.6) * 100) / 100;		// 2 decimal places
 const kphToMph = (Kph) => Math.round(Kph / 1.609_34);
+const kphToBft = (Kph) => [1,6,12,20,29,39,50,62,75,89,103,118,Infinity].findIndex(b => Kph < b);
 const knotsToMs = (Knots) => {
 	const result = Math.round((Knots * 0.514_444) * 100) / 100; // 2 decimal places
 	return result;
@@ -32,6 +33,7 @@ export {
 	kphToKnots,
 	kphToMs,
 	kphToMph,
+	kphToBft,
 	knotsToMs,
 
 	celsiusToFahrenheit,


### PR DESCRIPTION
Added Beaufort (bft) as an option for wind units. Bft is often used in the Netherlands for weather forecast wind speeds.

Necessary functions for conversion from km/h to bft, unit text, exports and settings stuff added.

Confirmed working in the hourly forecast view and bottom text. There are some km/h's that seem fixed though, like the local forecast, but that's a different problem.

<img width="980" height="791" alt="image" src="https://github.com/user-attachments/assets/3f8951bd-bead-42c6-8087-03a7bff6f0d3" />
