### PR TITLE
Added specific build command for Windows only

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,11 @@ After running this project in either way, pen your web browser:
 `ws4kp-international`'s main "showcase" is a deployed instance via GitHub Pages. To prepare a new release run the following command:
 
 ```
+# Mac & Linux users
 npm run build
+
+# Windows users
+npm run build:win
 ```
 
 This will update the artifacts in the `/docs` folder. Simply commit them as part of your branch, and push them to remote. Deployment will be handled automatically when your PR is merged into `main`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
 		"lint:fix": "eslint --fix ./server/scripts/**/*.mjs",
 		"start": "nodemon index.js",
 		"copy-assets": "mkdir -p docs/images && cp -r ./server/images docs && mkdir -p docs/fonts && cp -r ./server/fonts docs",
-		"build": "rm -rf docs/ && gulp && npm run copy-assets"
+		"build": "rm -rf docs/ && gulp && npm run copy-assets",
+		"copy-assets:win": "cmd /c \"mkdir docs\\images && xcopy /e /i /y server\\images docs\\images && mkdir docs\\fonts && xcopy /e /i /y server\\fonts docs\\fonts\"",
+		"build:win": "cmd /c \"rmdir /s /q docs && gulp && npm run copy-assets:win\""
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

> Briefly describe the purpose of this PR

As rm and cp don't work on Windows I've created build:win and copy-assets:win run options that are Windows specific. This way no extra dependencies are introduced just for deleting and copying some files during the build process. Uses basic windows tools: cmd, rmdir & xcopy.

## Checklist

1. [x] This PR focuses on a single change, feature, or theme
1. [x] Code is clear, commented, and documented (where needed)
1. [ ] Version bumped appropriately (see below)
1. [ ] `npm run build` was run (if applicable - see below)

Version not bumped as it does impact the user.

## Version Bump & Build (Important)

If your change affects users, you must bump the version in `package.json` - here:
- https://github.com/mwood77/ws4kp-international/blob/e26f66ae6dd28ac73f62ff0e1d4ca75d6b3f9bcd/package.json#L3

Versioning uses [Semantic Versioning](https://semver.org):

- `PATCH` – small fix or tweak (`1.2.3` → `1.2.4`)
- `MINOR` – adds backward-compatible features (`1.2.3` → `1.3.0`)
- `MAJOR` – breaking changes (`1.2.3` → `2.0.0`)

After you've updated the version, you now need to build the project and attach the output. Simply run this in your terminal:

```bash
npm run build
```

And then commit the changed files (the build).

Deployment is handled automatically when the code is merged into the `main` branch.

No build made as it doesn't impact the app. Can still be done if necessary.